### PR TITLE
5.7 Support and using Route::apiResource

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "version": "0.1.8",
     "require": {
-        "laravel/framework": "5.4.*|5.5.*|5.6.*"
+        "laravel/framework": "5.4.*|5.5.*|5.6.*|5.7.*"
     },
     "autoload": {
         "psr-4": {

--- a/src/Generators/ApiRouteGenerator.php
+++ b/src/Generators/ApiRouteGenerator.php
@@ -53,7 +53,7 @@ class ApiRouteGenerator
 
     public function resource($name)
     {
-        $line = "Route::resource('" . lcfirst($name) . "', 'Api\\" . $name . "Controller', ['except' => ['create', 'edit']]);";
+        $line = "Route::apiResource('" . lcfirst($name) . "', 'Api\\" . $name . "Controller');";
         if (!$this->blockHasResource($name)) {
             $this->block[] = $line;
             return false;


### PR DESCRIPTION
Laravel has a Route::apiResource function that automatically ignores the create and edit route actions. This is better for APIs than using Route::resource and ignore it manually.

I also added support for Laravel 5.7.*